### PR TITLE
Fixing latency when app is down

### DIFF
--- a/.github/workflows/bumpr.yaml
+++ b/.github/workflows/bumpr.yaml
@@ -1,0 +1,45 @@
+name: Create Tag & Release
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - labeled
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  comment-pr:
+    if: github.event.action == 'labeled'
+    runs-on: ubuntu-latest
+    name: Comment on PR the version to be released
+    steps:
+      - uses: actions/checkout@v2
+      - name: Post bumpr status comment
+        uses: haya14busa/action-bumpr@v1
+  create-tag-and-release:
+    if: github.event.action != 'labeled'
+    runs-on: ubuntu-latest
+    name: Bump tag and cut release
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Bumpr Create Tag
+        id: bumpr
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        uses: haya14busa/action-bumpr@v1
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.bumpr.outputs.next_version }}
+          name: Version ${{ steps.bumpr.outputs.next_version }}
+          generate_release_notes: true
+          draft: false
+          prerelease: false

--- a/src/main.go
+++ b/src/main.go
@@ -98,6 +98,7 @@ func checkEndpoint(endpoint *EndpointCheck, stopChan <-chan struct{}) {
 			if err != nil {
 				fmt.Printf("Error checking %s: %v\n", endpoint.Name, err)
 				statusGauge.WithLabelValues(endpoint.Name).Set(0)
+				latencyGauge.WithLabelValues(endpoint.Name).Set(0) // Set latency to 0 on error
 			} else {
 				resp.Body.Close()
 				fmt.Printf("%s: Latency: %dms\n", endpoint.Name, latency)


### PR DESCRIPTION
When an app goes down, the endpoint still registers a time it took to get that response, giving the impression that it was still up

This PR fixes that

![image](https://github.com/userbradley/prom-status/assets/41597815/1020cd5a-a5a3-4eed-b6b6-b052ff35ca99)
